### PR TITLE
Use env vars for DB credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ build/
 
 
 .env
+src/main/resources/application.properties

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Valoren Chatbot
+
+This project is a Spring Boot application for a WhatsApp chatbot. Configuration values are loaded from environment variables using the [dotenv-java](https://github.com/cdimascio/dotenv-java) library.
+
+## Required environment variables
+
+Set the following variables in your shell or in a `.env` file at the project root:
+
+- `DB_USERNAME` – database username
+- `DB_PASSWORD` – database password
+- `BOT_NUMBER` – WhatsApp bot phone number
+- `PEPIPOST_API_KEY` – API key for Netcore
+- `PEPIPOST_BASE_URL` – base URL for sending messages
+- `TEMPLATE_BASE_URL` – base URL for template operations
+
+## Running the application
+
+1. Ensure PostgreSQL is running and accessible via the URL configured in `src/main/resources/application.properties`.
+2. Provide the environment variables above.
+3. Start the application with Maven:
+   ```bash
+   ./mvnw spring-boot:run
+   ```
+
+The application will read values from the environment at startup.

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=chatbot
 spring.datasource.url=jdbc:postgresql://localhost:5432/message_logs
-spring.datasource.username=postgres
-spring.datasource.password=password
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
## Summary
- externalize DB credentials via `DB_USERNAME` and `DB_PASSWORD`
- document environment variables in new README
- ignore local `application.properties`

## Testing
- `./mvnw -q test` *(fails: could not fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686ce47aff98832f9517102804b2ff8a